### PR TITLE
Add orf1b annotation to sequence GenBank files

### DIFF
--- a/gensplore-component/public/sequence.gb
+++ b/gensplore-component/public/sequence.gb
@@ -174,6 +174,13 @@ FEATURES             Location/Qualifiers
                      FFTYICGFIQQKLALGGSVAIKITEHSWNADLYKLMGHFAWWTAFVTNVNASSSEAFL
                      IGCNYLGKPREQIDGYVMHANYIFWRNTNPIQLSSYSLFDMSKFPLKLRGTAVMSLKE
                      GQINDMILSLLSKGRLIIRENNRVVISSDVLVNN"
+     gene            13468..21555
+                     /gene="orf1b"
+     CDS             13468..21555
+                     /gene="orf1b"
+                     /note="pp1b"
+                     /codon_start=1
+                     /product="orf1b polyprotein"
      gene            21563..25384
                      /gene="S"
      CDS             21563..25384

--- a/website/public/sequence.gb
+++ b/website/public/sequence.gb
@@ -174,6 +174,13 @@ FEATURES             Location/Qualifiers
                      FFTYICGFIQQKLALGGSVAIKITEHSWNADLYKLMGHFAWWTAFVTNVNASSSEAFL
                      IGCNYLGKPREQIDGYVMHANYIFWRNTNPIQLSSYSLFDMSKFPLKLRGTAVMSLKE
                      GQINDMILSLLSKGRLIIRENNRVVISSDVLVNN"
+     gene            13468..21555
+                     /gene="orf1b"
+     CDS             13468..21555
+                     /gene="orf1b"
+                     /note="pp1b"
+                     /codon_start=1
+                     /product="orf1b polyprotein"
      gene            21563..25384
                      /gene="S"
      CDS             21563..25384


### PR DESCRIPTION
### Motivation
- Ensure the ORF1b region is explicitly annotated in the project's GenBank sequence assets so downstream tools and viewers can detect the orf1b gene and its CDS. 
- Keep the distributed `website` and `gensplore-component` sequence files consistent by mirroring the same annotation in both copies.

### Description
- Inserted a `gene` feature for `orf1b` at `13468..21555` in `website/public/sequence.gb` and `gensplore-component/public/sequence.gb`.
- Added a corresponding `CDS` block for `orf1b` with `/note="pp1b"`, `/codon_start=1`, and `/product="orf1b polyprotein"` to both files.
- Only the two GenBank files were modified; no code or behavior changes were made.

### Testing
- Verified the new annotations exist with `rg -n 'gene="orf1b"|product="orf1b polyprotein"' website/public/sequence.gb gensplore-component/public/sequence.gb`, which returned the inserted entries successfully. 
- Created a commit with `git commit -m "Add orf1b annotation to sequence GenBank files"`, which completed successfully. 
- No automated unit or integration test suite was run because this change is a data/annotation update only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f113fd6d1883259d4f332cf400ef0a)